### PR TITLE
feat: add customizable dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,27 @@
+const DASHBOARD_KEY = 'dashboardCards';
+const COLORS = ['#EF4444','#F97316','#EAB308','#84CC16','#22C55E','#14B8A6','#3B82F6','#8B5CF6','#EC4899','#F43F5E'];
+
+function getCards(){
+  try { return JSON.parse(localStorage.getItem(DASHBOARD_KEY)) || []; }
+  catch { return []; }
+}
+
+function saveCards(cards){
+  localStorage.setItem(DASHBOARD_KEY, JSON.stringify(cards.slice(0,20)));
+}
+
+async function fetchEvents(){
+  const res = await fetch('/api/events');
+  return await res.json();
+}
+
+function groupData(events, groupBy){
+  const counts = {};
+  events.forEach(e => {
+    const key = e[groupBy];
+    counts[key] = (counts[key] || 0) + 1;
+  });
+  return { labels: Object.keys(counts), data: Object.values(counts) };
+}
+
+window.dashboardUtils = { getCards, saveCards, fetchEvents, groupData, COLORS };

--- a/public/index.html
+++ b/public/index.html
@@ -3,41 +3,78 @@
 <head>
   <meta charset="utf-8" />
   <title>Analytics Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="dashboard.js"></script>
 </head>
 <body>
-  <h1>Analytics Dashboard</h1>
-  <canvas id="eventChart" width="400" height="200"></canvas>
-  <table border="1" id="eventTable">
-    <thead>
-      <tr><th>Application</th><th>Event</th><th>Timestamp</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <header>
+    <h1>Analytics Dashboard</h1>
+    <a href="reports.html">Add Card</a>
+  </header>
+  <div id="dashboard" class="dashboard"></div>
   <script>
-    async function loadEvents(){
-      const res = await fetch('/api/events');
-      const events = await res.json();
-      const counts = {};
-      events.forEach(e => {
-        const key = e.application + ':' + e.event;
-        counts[key] = (counts[key]||0)+1;
-      });
-      const labels = Object.keys(counts);
-      const data = Object.values(counts);
-      new Chart(document.getElementById('eventChart'), {
-        type:'bar',
-        data:{ labels, datasets:[{ label:'Events', data }] }
-      });
-      const tbody=document.querySelector('#eventTable tbody');
-      tbody.innerHTML='';
-      events.forEach(e=>{
-        const tr=document.createElement('tr');
-        tr.innerHTML = `<td>${e.application}</td><td>${e.event}</td><td>${e.timestamp}</td>`;
-        tbody.appendChild(tr);
+  (async () => {
+    const {getCards, saveCards, fetchEvents, groupData, COLORS} = window.dashboardUtils;
+    const events = await fetchEvents();
+    const dashboardEl = document.getElementById('dashboard');
+
+    function removeCard(id){
+      const cards = getCards().filter(c => c.id !== id);
+      saveCards(cards);
+      render();
+    }
+
+    function render(){
+      dashboardEl.innerHTML = '';
+      const cards = getCards();
+      cards.forEach(card => {
+        const cardEl = document.createElement('div');
+        cardEl.className = 'card';
+        cardEl.dataset.id = card.id;
+        const title = document.createElement('h3');
+        title.textContent = card.title;
+        const canvas = document.createElement('canvas');
+        canvas.height = 250;
+        const btn = document.createElement('button');
+        btn.className = 'remove';
+        btn.textContent = '\u00d7';
+        btn.onclick = () => removeCard(card.id);
+        cardEl.appendChild(title);
+        cardEl.appendChild(canvas);
+        cardEl.appendChild(btn);
+        dashboardEl.appendChild(cardEl);
+        const grouped = groupData(events, card.groupBy);
+        const colors = COLORS;
+        new Chart(canvas, {
+          type: card.chartType,
+          data: {
+            labels: grouped.labels,
+            datasets: [{
+              label: card.title,
+              data: grouped.data,
+              backgroundColor: colors,
+              borderColor: colors,
+              fill: card.chartType !== 'line'
+            }]
+          },
+          options: { responsive: true, maintainAspectRatio: false }
+        });
       });
     }
-    loadEvents();
+
+    render();
+
+    Sortable.create(dashboardEl, {
+      animation:150,
+      onEnd: () => {
+        const order = Array.from(document.querySelectorAll('.card')).map(c => +c.dataset.id);
+        const cards = getCards().sort((a,b) => order.indexOf(a.id) - order.indexOf(b.id));
+        saveCards(cards);
+      }
+    });
+  })();
   </script>
 </body>
 </html>

--- a/public/reports.html
+++ b/public/reports.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Create Report</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="dashboard.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Create Report</h1>
+    <a href="index.html">Back</a>
+  </header>
+  <form id="reportForm">
+    <label>Title
+      <input type="text" id="title" required />
+    </label>
+    <label>Group By
+      <select id="group">
+        <option value="application">Application</option>
+        <option value="event">Event</option>
+      </select>
+    </label>
+    <label>Chart Type
+      <select id="chartType">
+        <option value="bar">Bar</option>
+        <option value="line">Line</option>
+        <option value="pie">Pie</option>
+        <option value="doughnut">Doughnut</option>
+        <option value="radar">Radar</option>
+        <option value="polarArea">Polar Area</option>
+      </select>
+    </label>
+    <button type="submit">Add to Dashboard</button>
+  </form>
+  <div id="previewContainer">
+    <canvas id="preview"></canvas>
+  </div>
+  <script>
+  (async () => {
+    const {getCards, saveCards, fetchEvents, groupData, COLORS} = window.dashboardUtils;
+    const events = await fetchEvents();
+    const form = document.getElementById('reportForm');
+    const previewCanvas = document.getElementById('preview');
+    let previewChart;
+
+    function renderPreview(){
+      const group = document.getElementById('group').value;
+      const chartType = document.getElementById('chartType').value;
+      const grouped = groupData(events, group);
+      if(previewChart){ previewChart.destroy(); }
+      previewChart = new Chart(previewCanvas, {
+        type: chartType,
+        data: {
+          labels: grouped.labels,
+          datasets: [{
+            label: group,
+            data: grouped.data,
+            backgroundColor: COLORS,
+            borderColor: COLORS,
+            fill: chartType !== 'line'
+          }]
+        },
+        options: { responsive:true, maintainAspectRatio:false }
+      });
+    }
+
+    form.addEventListener('change', renderPreview);
+    renderPreview();
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const title = document.getElementById('title').value.trim() || 'Chart';
+      const group = document.getElementById('group').value;
+      const chartType = document.getElementById('chartType').value;
+      const cards = getCards();
+      if(cards.length >= 20){
+        alert('Maximum of 20 cards reached');
+        return;
+      }
+      cards.push({ id: Date.now(), title, groupBy: group, chartType });
+      saveCards(cards);
+      window.location.href = 'index.html';
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,76 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(120deg, #f0f4f7, #e0e7ff);
+  margin: 0;
+  min-height: 100vh;
+}
+header {
+  background: #1e3a8a;
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+header a {
+  color: #fbbf24;
+  text-decoration: none;
+  font-weight: bold;
+}
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  padding: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+.card h3 {
+  margin-top: 0;
+}
+.card button.remove {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  color: #dc2626;
+  cursor: pointer;
+}
+form {
+  max-width: 500px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+form label {
+  display: block;
+  margin: 0.5rem 0;
+}
+form input, form select {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+}
+form button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #1e3a8a;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#previewContainer {
+  width: 100%;
+  height: 300px;
+}


### PR DESCRIPTION
## Summary
- allow users to build a dashboard of up to 20 Chart.js cards
- enable removing and drag-and-drop reordering of dashboard cards
- add reports screen to configure charts and polished styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c00c57d7d8832ba3c48006f1669604