### PR TITLE
feat: add event testing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,10 @@
 <body>
   <header>
     <h1>Analytics Dashboard</h1>
-    <a href="reports.html">Add Card</a>
+    <nav>
+      <a href="reports.html">Add Card</a>
+      <a href="test-event.html">Send Event</a>
+    </nav>
   </header>
   <div id="dashboard" class="dashboard"></div>
   <script>

--- a/public/style.css
+++ b/public/style.css
@@ -17,6 +17,9 @@ header a {
   text-decoration: none;
   font-weight: bold;
 }
+header a + a {
+  margin-left: 1rem;
+}
 .dashboard {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));

--- a/public/test-event.html
+++ b/public/test-event.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Send Test Event</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Send Test Event</h1>
+    <a href="index.html">Back</a>
+  </header>
+  <form id="eventForm">
+    <label>Application
+      <input type="text" id="application" required />
+    </label>
+    <label>Event
+      <input type="text" id="event" required />
+    </label>
+    <button type="submit">Send Event</button>
+  </form>
+  <div id="status"></div>
+  <script>
+    document.getElementById('eventForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const application = document.getElementById('application').value.trim();
+      const event = document.getElementById('event').value.trim();
+      const statusEl = document.getElementById('status');
+      statusEl.textContent = '';
+      try {
+        const res = await fetch('/api/events', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ application, event })
+        });
+        statusEl.textContent = res.ok ? 'Event sent' : `Error: ${res.status}`;
+      } catch (err) {
+        statusEl.textContent = 'Error sending event';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple page to submit test events
- link tester from dashboard and adjust header spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05df5894c832baa102b2f0d5d265c